### PR TITLE
Modify instructions after app creation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,7 @@ gulp.task('create-app', function(done) {
       .pipe(conflict('./apps/'  + answers.name))                    // Confirms overwrites on file conflicts
       .pipe(gulp.dest('./apps/' + answers.name))                   // Without __dirname here = relative to cwd
       .on('finish', function () {
-        console.log('[' + 'getCoding'.green + ']', 'Add `require(\'apps/' + answers.name + '\')` to apps/main/index.js and you are good to go.')
+        console.log('[' + 'getCoding'.green + ']', 'Add `require(\'/apps/' + answers.name + '\')` to apps/main/index.js and you are good to go.')
         done();                                // Finished!
       });
   });


### PR DESCRIPTION
This fixes a minor little typo that causes a stumbling block when creating a new application. If you don't have the slash, then it looks for a Github repository—which is not what we want in this case.
